### PR TITLE
Fixed the use of field.name for components

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -63,7 +63,7 @@
                 <template v-if="field.visible">
                   <template v-if="isFieldComponent(field.name)">
                     <component
-                      :is="field.name"
+                      :is="field.name.substr(25)"
                       :key="fieldIndex"
                       :row-data="item"
                       :row-index="itemIndex"


### PR DESCRIPTION
We were not able to use the field type __component because of the string added to the front of the component name. This small fix removed the string in front of the component name.

https://github.com/mannyyang/vuetable-3/issues/11