### PR TITLE
Comment out the use of the slot and component in the header

### DIFF
--- a/src/components/VuetableRowHeader.vue
+++ b/src/components/VuetableRowHeader.vue
@@ -2,7 +2,7 @@
   <tr>
     <template v-for="(field, fieldIndex) in vuetable.tableFields">
       <template v-if="field.visible">
-        <template v-if="vuetable.isFieldComponent(field.name)">
+        <!-- <template v-if="vuetable.isFieldComponent(field.name)">
           <component
             :is="field.name"
             :row-field="field"
@@ -30,8 +30,8 @@
             v-html="renderTitle(field)"
             @click="onColumnHeaderClicked(field, $event)"
           ></th>
-        </template>
-        <template v-else>
+        </template> -->
+        <template>
           <th
             @click="onColumnHeaderClicked(field, $event)"
             :key="fieldIndex"


### PR DESCRIPTION
I am not sure how to use this new VuetableRowHeader.vue component.

If I use a slot or a component for the field this also seems to want to use the exact same component or slot in the header. This seems to be an odd outcome and I am unable to work out how to just use the normal header element when using a special field,

There is no documentation on the site as to how to use it but it does make one reference to it will be customised.
![Screenshot from 2021-10-06 11-36-20](https://user-images.githubusercontent.com/832259/136137008-d17c2ce6-50d9-46dd-ba26-07f428838a33.png)

Until there is more information around the use of a special field as the header propose just use the normal header cell element.

I do notice that the component header template was missing 

```js
   v-html="renderTitle(field)"
```

How ever even with this the style is different you loose the sort component also