### PR TITLE
Fix Build Error

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -5,10 +5,9 @@
         <vuetable-col-group :is-header="true" />
         <thead>
           <slot name="tableHeader" :fields="tableFields">
-            <template v-for="(header, headerIndex) in headerRows">
+            <template v-for="(header, headerIndex) in headerRows" :key="headerIndex">
               <component
                 :is="header"
-                :key="headerIndex"
                 @vuetable:header-event="onHeaderEvent"
               ></component>
             </template>
@@ -33,10 +32,9 @@
         <vuetable-col-group />
         <thead v-if="!isFixedHeader">
           <slot name="tableHeader" :fields="tableFields">
-            <template v-for="(header, headerIndex) in headerRows">
+            <template v-for="(header, headerIndex) in headerRows" :key="headerIndex">
               <component
                 :is="header"
-                :key="headerIndex"
                 @vuetable:header-event="onHeaderEvent"
               ></component>
             </template>
@@ -50,21 +48,19 @@
           ></slot>
         </tfoot>
         <tbody v-cloak class="vuetable-body">
-          <template v-for="(item, itemIndex) in tableData">
+          <template v-for="(item, itemIndex) in tableData" :key="itemIndex">
             <tr
               :item-index="itemIndex"
-              :key="itemIndex"
               :class="onRowClass(item, itemIndex)"
               @click="onRowClicked(item, itemIndex, $event)"
               @dblclick="onRowDoubleClicked(item, itemIndex, $event)"
               @mouseover="onMouseOver(item, itemIndex, $event)"
             >
-              <template v-for="(field, fieldIndex) in tableFields">
+              <template v-for="(field, fieldIndex) in tableFields" :key="fieldIndex">
                 <template v-if="field.visible">
                   <template v-if="isFieldComponent(field.name)">
                     <component
                       :is="field.name"
-                      :key="fieldIndex"
                       :row-data="item"
                       :row-index="itemIndex"
                       :row-field="field"
@@ -77,7 +73,6 @@
                   <template v-else-if="isFieldSlot(field.name)">
                     <td
                       :class="bodyClass('vuetable-slot', field)"
-                      :key="fieldIndex"
                       :style="{ width: field.width }"
                     >
                       <slot
@@ -91,7 +86,6 @@
                   <template v-else>
                     <td
                       :class="bodyClass('vuetable-td-' + field.name, field)"
-                      :key="fieldIndex"
                       :style="{ width: field.width }"
                       v-html="renderNormalField(field, item)"
                       @click="onCellClicked(item, itemIndex, field, $event)"
@@ -136,8 +130,8 @@
           </template>
           <template v-if="lessThanMinRows">
             <tr v-for="i in blankRows" class="blank-row" :key="i">
-              <template v-for="(field, fieldIndex) in tableFields">
-                <td v-if="field.visible" :key="fieldIndex">&nbsp;</td>
+              <template v-for="(field, fieldIndex) in tableFields" :key="fieldIndex">
+                <td v-if="field.visible">&nbsp;</td>
               </template>
             </tr>
           </template>

--- a/src/components/VuetablePagination.vue
+++ b/src/components/VuetablePagination.vue
@@ -26,10 +26,9 @@
       <span v-else>&nbsp;&lsaquo;</span>
     </a>
     <template v-if="notEnoughPages">
-      <template v-for="(n, i) in totalPage">
+      <template v-for="(n, i) in totalPage" :key="i">
         <a
           @click="loadPage(i + firstPage)"
-          :key="i"
           :class="[
             $_css.pageClass,
             isCurrentPage(i + firstPage) ? $_css.activeClass : ''
@@ -40,10 +39,9 @@
       </template>
     </template>
     <template v-else>
-      <template v-for="(n, i) in windowSize">
+      <template v-for="(n, i) in windowSize" :key="i">
         <a
           @click="loadPage(windowStart + i + firstPage - 1)"
-          :key="i"
           :class="[
             $_css.pageClass,
             isCurrentPage(windowStart + i + firstPage - 1)


### PR DESCRIPTION
# TL; DR

In a project utilizing `vuetable-3`, our build system is stopped by a build error that traces through the package. The cause is the `key` attribute not being correctly implemented in `v-for` loops. This pull request resolves this problem.

# Full Build Error

```
ERROR in ./node_modules/vuetable-3/src/components/Vuetable.vue?vue&type=template&id=3ee642bc (./node_modules/vue-loader/dist/templateLoader.js??ruleSet[1].rules[2]!./node_modules/vue-loader/dist/index.js??ruleSet[0]!./node_modules/vuetable-3/src/components/Vuetable.vue?vue&type=template&id=3ee642bc)
Module Error (from ./node_modules/vue-loader/dist/templateLoader.js):

VueCompilerError: <template v-for> key should be placed on the <template> tag.
at /home/deepdivedylan/node_modules/vuetable-3/src/components/Vuetable.vue:11:17
9  |                <component
10 |                  :is="header"
11 |                  :key="headerIndex"
   |                  ^^^^^^^^^^^^^^^^^^
12 |                  @vuetable:header-event="onHeaderEvent"
13 |                ></component>
 @ ./node_modules/vuetable-3/src/components/Vuetable.vue?vue&type=template&id=3ee642bc 1:0-172 1:0-172
 @ ./node_modules/vuetable-3/src/components/Vuetable.vue 1:0-69 8:68-74
 @ ./static-src/main.js 10:15-75

ERROR in ./node_modules/vuetable-3/src/components/Vuetable.vue?vue&type=template&id=3ee642bc (./node_modules/vue-loader/dist/templateLoader.js??ruleSet[1].rules[2]!./node_modules/vue-loader/dist/index.js??ruleSet[0]!./node_modules/vuetable-3/src/components/Vuetable.vue?vue&type=template&id=3ee642bc)
Module Error (from ./node_modules/vue-loader/dist/templateLoader.js):

VueCompilerError: <template v-for> key should be placed on the <template> tag.
at /home/deepdivedylan/node_modules/vuetable-3/src/components/Vuetable.vue:39:17
37 |                <component
38 |                  :is="header"
39 |                  :key="headerIndex"
   |                  ^^^^^^^^^^^^^^^^^^
40 |                  @vuetable:header-event="onHeaderEvent"
41 |                ></component>
 @ ./node_modules/vuetable-3/src/components/Vuetable.vue?vue&type=template&id=3ee642bc 1:0-172 1:0-172
 @ ./node_modules/vuetable-3/src/components/Vuetable.vue 1:0-69 8:68-74
 @ ./static-src/main.js 10:15-75

ERROR in ./node_modules/vuetable-3/src/components/Vuetable.vue?vue&type=template&id=3ee642bc (./node_modules/vue-loader/dist/templateLoader.js??ruleSet[1].rules[2]!./node_modules/vue-loader/dist/index.js??ruleSet[0]!./node_modules/vuetable-3/src/components/Vuetable.vue?vue&type=template&id=3ee642bc)
Module Error (from ./node_modules/vue-loader/dist/templateLoader.js):

VueCompilerError: <template v-for> key should be placed on the <template> tag.
at /home/deepdivedylan/node_modules/vuetable-3/src/components/Vuetable.vue:56:15
54 |              <tr
55 |                :item-index="itemIndex"
56 |                :key="itemIndex"
   |                ^^^^^^^^^^^^^^^^
57 |                :class="onRowClass(item, itemIndex)"
58 |                @click="onRowClicked(item, itemIndex, $event)"
 @ ./node_modules/vuetable-3/src/components/Vuetable.vue?vue&type=template&id=3ee642bc 1:0-172 1:0-172
 @ ./node_modules/vuetable-3/src/components/Vuetable.vue 1:0-69 8:68-74
 @ ./static-src/main.js 10:15-75

ERROR in ./node_modules/vuetable-3/src/components/VuetablePagination.vue?vue&type=template&id=acfbe714 (./node_modules/vue-loader/dist/templateLoader.js??ruleSet[1].rules[2]!./node_modules/vue-loader/dist/index.js??ruleSet[0]!./node_modules/vuetable-3/src/components/VuetablePagination.vue?vue&type=template&id=acfbe714)
Module Error (from ./node_modules/vue-loader/dist/templateLoader.js):

VueCompilerError: <template v-for> key should be placed on the <template> tag.
at /home/deepdivedylan/node_modules/vuetable-3/src/components/VuetablePagination.vue:32:11
30 |          <a
31 |            @click="loadPage(i + firstPage)"
32 |            :key="i"
   |            ^^^^^^^^
33 |            :class="[
34 |              $_css.pageClass,
 @ ./node_modules/vuetable-3/src/components/VuetablePagination.vue?vue&type=template&id=acfbe714 1:0-182 1:0-182
 @ ./node_modules/vuetable-3/src/components/VuetablePagination.vue 1:0-79 8:68-74
 @ ./static-src/main.js 11:25-95

ERROR in ./node_modules/vuetable-3/src/components/VuetablePagination.vue?vue&type=template&id=acfbe714 (./node_modules/vue-loader/dist/templateLoader.js??ruleSet[1].rules[2]!./node_modules/vue-loader/dist/index.js??ruleSet[0]!./node_modules/vuetable-3/src/components/VuetablePagination.vue?vue&type=template&id=acfbe714)
Module Error (from ./node_modules/vue-loader/dist/templateLoader.js):

VueCompilerError: <template v-for> key should be placed on the <template> tag.
at /home/deepdivedylan/node_modules/vuetable-3/src/components/VuetablePagination.vue:46:11
44 |          <a
45 |            @click="loadPage(windowStart + i + firstPage - 1)"
46 |            :key="i"
   |            ^^^^^^^^
47 |            :class="[
48 |              $_css.pageClass,
 @ ./node_modules/vuetable-3/src/components/VuetablePagination.vue?vue&type=template&id=acfbe714 1:0-182 1:0-182
 @ ./node_modules/vuetable-3/src/components/VuetablePagination.vue 1:0-79 8:68-74
 @ ./static-src/main.js 11:25-95

5 errors have detailed information that is not shown.
```